### PR TITLE
GT-85 Streamed show event not firing when player first launched

### DIFF
--- a/addon/components/listen-button.js
+++ b/addon/components/listen-button.js
@@ -44,7 +44,7 @@ export default Component.extend({
 
   tagName:              'button',
   classNames:           ['listen-button'],
-  classNameBindings:    ['isHovering', 'type', 'isCurrentSound', 'isErrored', 'playState', 'isCurrentSound'],
+  classNameBindings:    ['isHovering', 'type', 'isCurrentSound', 'isErrored', 'playState', 'isCurrentSound', 'isLive'],
   attributeBindings:    ['aria-label', 'title', 'disabled', 'data-test-selector', 'style', 'data-story', 'data-show'],
 
   title: computed('itemTitle', function() {

--- a/addon/components/listen-button.js
+++ b/addon/components/listen-button.js
@@ -41,11 +41,12 @@ export default Component.extend({
   'data-test-selector': 'listen-button',
   'data-story'        : readOnly('itemTitle'),
   'data-show'         : readOnly('itemShow'),
+  'data-stream'       : readOnly('itemStream'),
 
   tagName:              'button',
   classNames:           ['listen-button'],
   classNameBindings:    ['isHovering', 'type', 'isCurrentSound', 'isErrored', 'playState', 'isCurrentSound', 'isLive'],
-  attributeBindings:    ['aria-label', 'title', 'disabled', 'data-test-selector', 'style', 'data-story', 'data-show'],
+  attributeBindings:    ['aria-label', 'title', 'disabled', 'data-test-selector', 'style', 'data-story', 'data-show', 'data-stream'],
 
   title: computed('itemTitle', function() {
     return `Listen to ${get(this, 'itemTitle')}`;

--- a/addon/components/nypr-player-integration/track-info.js
+++ b/addon/components/nypr-player-integration/track-info.js
@@ -16,16 +16,17 @@ export default Ember.Component.extend({
   songDetails   : null,
 
   didReceiveAttrs: diffAttrs('showTitle', function(changedAttrs, ...args) {
-     this._super(...args);
+    this._super(...args);
+    let isInitialRender = changedAttrs === null;
 
-     if(changedAttrs && changedAttrs.showTitle) {
-       let oldTitle = changedAttrs.showTitle[0],
-           newTitle = changedAttrs.showTitle[1];
-       if (newTitle === oldTitle || !this.get('isStream')) { return; }
+    let showTitleChanged = changedAttrs
+      && changedAttrs.showTitle
+      && changedAttrs.showTitle[0] !== changedAttrs.showTitle[1];
 
-       if (this.attrs.trackStreamData) {
-         this.attrs.trackStreamData();
-       }
+    if (isInitialRender || showTitleChanged) {
+     if (this.attrs.titleDidChange) {
+       this.attrs.titleDidChange();
      }
-   })
+    }
+  })
 });

--- a/addon/templates/components/queue-listitem.hbs
+++ b/addon/templates/components/queue-listitem.hbs
@@ -46,7 +46,7 @@
         playContext=playContext
         itemPK=story.id
         itemTitle=story.title
-        itemShow=story.showTitle}}
+        itemShow=(or story.showTitle story.headers.brand.title)}}
     </div>
   {{/g.right}}
 {{/holygrail-layout}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4877,7 +4877,7 @@ nypr-metrics@nypublicradio/nypr-metrics:
 
 nypr-ui@nypublicradio/nypr-ui:
   version "0.0.0"
-  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/978b09c9926dbf738c8cfbebbfecefa4136e7fd9"
+  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/19c5bb2333944a51fcba9cf94bbf2aec6c6d2670"
   dependencies:
     ember-basic-dropdown "0.33.1"
     ember-cli-babel "^6.6.0"


### PR DESCRIPTION
https://jira.wnyc.org/browse/GT-85
> * "Streamed Show" and "Streamed Story" are not firing consistently. I launched the stream at 11:30 am during the Brian Lehrer show, but neither of those events fired.
>   * From what I can tell...the event will fire if you launch the stream while listening to other content. If you start without the player opened, the Streamed Story and Streamed Show events do not fire. (I am not sure how true this is across the board, but that’s the pattern I’ve seen so far.)
>   * It fired when I let the livestream launch via continuous play

Instead of `track-info` being passed a trackStreamData action when the title changes, i've changed it to a titleDidChange action. It shouldn't need to know about tracking.

This event fires on initial render by checking for a null changedAttrs property. 

It should fire regardless of isStream state, that logic can handled by the passed in action.

This depends on https://github.com/nypublicradio/wnyc-web-client/pull/178