### PR TITLE
addBrowserId method

### DIFF
--- a/addon/services/dj.js
+++ b/addon/services/dj.js
@@ -146,5 +146,12 @@ export default Service.extend({
 
   pause() {
     get(this, 'hifi').pause();
+  },
+
+  addBrowserId(id) {
+    get(this, 'hifi').on('pre-load', strategy => {
+      let { url } = strategy;
+      strategy.url = `${url}?browser_id=${id}`;
+    });
   }
 });


### PR DESCRIPTION
add the given browser id as a query param to any outgoing audio request

[ticket](https://jira.wnyc.org/browse/RT-701)

tests will fail until https://github.com/nypublicradio/nypr-audio-services/pull/9 is merged