### PR TITLE
add 2 more station stream slugs (from prod publisher) 

### DIFF
--- a/addon/services/dj.js
+++ b/addon/services/dj.js
@@ -9,7 +9,7 @@ import { and, not, reads } from '@ember/object/computed';
 stream/story model and DJ will queue it up on the hifi with the appropriate
 metadata inserted */
 
-const STREAMS = ['wqxr', 'q2', 'wqxr-special', 'wnyc-fm939', 'wnyc-am820', 'njpr', 'jonathan-channel', 'special-events-stream', 'wqxr-special2', 'takeaway'];
+const STREAMS = ['wqxr', 'q2', 'wqxr-special', 'wnyc-fm939', 'wnyc-am820', 'njpr', 'jonathan-channel', 'special-events-stream', 'wqxr-special2', 'takeaway', 'wqxr-special2-same-as-holiday', 'indivisible'];
 
 export default Service.extend({
   hifi                : service(),


### PR DESCRIPTION
2 station streams listed in production weren't in the array of stream identifiers