### PR TITLE
Add position to metadata

### DIFF
--- a/addon/services/dj.js
+++ b/addon/services/dj.js
@@ -128,6 +128,7 @@ export default Service.extend({
     metadata.contentId = itemId;
     metadata.contentModelType = itemModelName;
     metadata.playContext = playContext;
+    metadata.position = position;
     metadata.autoPlayChoice = autoPlayChoice;
 
     let playRequest = get(this, 'hifi').play(audioUrlPromise, {metadata, position});


### PR DESCRIPTION
- Report position in audio items' metadata, so it can be exposed to analytics reporting.