### PR TITLE
Add listenButtonClickedAction to listen-button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.5.7
 
-- [ENHANCEMENT] Add an optional `listenButtonClickedAction` parameter to `listen-button` to be invoked as a callback when `listen-button` is tapped when in a `play` (as opposed to `pause`) state.
+- [ENHANCEMENT] Add an optional `playButtonClickedAction` parameter to `listen-button` to be invoked as a callback when `listen-button` is tapped when in a `play` (as opposed to `pause`) state.
 
 ## 0.5.6
 - [ENHANCEMENT] change Music Playlist to Music Play History on popup player

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # nypr-audio-services Changelog
 
+## 0.5.7
+
+- [ENHANCEMENT] Add an optional `listenButtonClickedAction` parameter to `listen-button` to be invoked as a callback when `listen-button` is tapped when in a `play` (as opposed to `pause`) state.
+
 ## 0.5.6
 - [ENHANCEMENT] change Music Playlist to Music Play History on popup player
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo is the home of all audio-related controls in use by the web-clients. I
   * Includes multiple variations that are controlled by a type parameter, which controls a set of CSS classes and inheritance
   * The bouncing animation is controlled by JS and based on a run-time measurement of the button's DOM dimensions
   * Includes a nested component which is configured to replace server-rendered HTML with an ember component
-  * Includes a callback parameter called `listenButtonClickedAction` to be invoked as a callback when `listen-button` is tapped when in a `play` (as opposed to `pause`) state.
+  * Includes a callback parameter called `playButtonClickedAction` to be invoked as a callback when `listen-button` is tapped when in a `play` (as opposed to `pause`) state.
 * `queue-button`
   * The primary UI widget for adding and removing a piece of audio to a local queue
 * `player-notification`

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repo is the home of all audio-related controls in use by the web-clients. I
   * Includes multiple variations that are controlled by a type parameter, which controls a set of CSS classes and inheritance
   * The bouncing animation is controlled by JS and based on a run-time measurement of the button's DOM dimensions
   * Includes a nested component which is configured to replace server-rendered HTML with an ember component
+  * Includes a callback parameter called `listenButtonClickedAction` to be invoked as a callback when `listen-button` is tapped when in a `play` (as opposed to `pause`) state.
 * `queue-button`
   * The primary UI widget for adding and removing a piece of audio to a local queue
 * `player-notification`

--- a/addon/components/listen-button.js
+++ b/addon/components/listen-button.js
@@ -26,6 +26,7 @@ export default Component.extend({
   layout,
   dj:                   service(),
   disabled:             not('dj.isReady'),
+  listenButtonClickedAction: () => {},
 
   isCurrentSound:       computed('dj.currentContentId', 'itemPK', function() {
     return get(this, 'itemPK') === get(this, 'dj.currentContentId');
@@ -146,6 +147,7 @@ export default Component.extend({
     } else {
       this.play();
     }
+    this.listenButtonClickedAction(event);
   },
 
   mouseLeave() {

--- a/addon/components/listen-button.js
+++ b/addon/components/listen-button.js
@@ -146,8 +146,8 @@ export default Component.extend({
       dj.pause();
     } else {
       this.play();
+      this.listenButtonClickedAction(event);
     }
-    this.listenButtonClickedAction(event);
   },
 
   mouseLeave() {

--- a/addon/components/listen-button.js
+++ b/addon/components/listen-button.js
@@ -26,7 +26,7 @@ export default Component.extend({
   layout,
   dj:                   service(),
   disabled:             not('dj.isReady'),
-  listenButtonClickedAction: () => {},
+  playButtonClickedAction: () => {},
 
   isCurrentSound:       computed('dj.currentContentId', 'itemPK', function() {
     return get(this, 'itemPK') === get(this, 'dj.currentContentId');
@@ -146,7 +146,7 @@ export default Component.extend({
       dj.pause();
     } else {
       this.play();
-      this.listenButtonClickedAction(event);
+      this.playButtonClickedAction(event);
     }
   },
 


### PR DESCRIPTION
Add an optional `listenButtonClickedAction` parameter to `listen-button` to be invoked as a callback when `listen-button` is tapped when in a `play` (as opposed to `pause`) state.